### PR TITLE
Validate headings for markdown only

### DIFF
--- a/src/LinkValidator/LocalLinkValidator.cs
+++ b/src/LinkValidator/LocalLinkValidator.cs
@@ -67,6 +67,11 @@ namespace MarkdownLinksVerifier.LinkValidator
 
         private static bool IsHeadingValid(string path, string headingIdWithoutHash)
         {
+            if (!path.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
             MarkdownPipeline pipeline = new MarkdownPipelineBuilder().UseAutoIdentifiers(AutoIdentifierOptions.GitHub).Build(); // TODO: Is AutoIdentifierOptions.GitHub the correct value to use?
             MarkdownDocument document = Markdown.Parse(File.ReadAllText(path), pipeline);
             return document.Descendants<HeadingBlock>().Any(heading => headingIdWithoutHash == heading.GetAttributes().Id);

--- a/tests/LinkValidatorTests/LocalLinkValidatorTests.cs
+++ b/tests/LinkValidatorTests/LocalLinkValidatorTests.cs
@@ -191,5 +191,27 @@ Hello world.
             Verify(writer.ToString().Split(writer.NewLine), expected);
             Assert.Equal(expected: 1, actual: returnCode);
         }
+
+        [Fact]
+        public async Task TestHeadingReferenceToNonMarkdownFile()
+        {
+            using var workspace = new Workspace
+            {
+                Files =
+                {
+                    { "/README.md", "[text](Program.cs#Snippet1)" },
+                    { "/Program.cs", "class Program {}" },
+                }
+            };
+
+            char separator = Path.DirectorySeparatorChar;
+
+            string workspacePath = await workspace.InitializeAsync();
+            using var writer = new StringWriter();
+            int returnCode = await WriteResultsAndGetExitCodeAsync(writer);
+
+            VerifyNoErrors(writer.ToString().Split(writer.NewLine));
+            Assert.Equal(expected: 0, actual: returnCode);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Youssef1313/markdown-links-verifier/issues/75